### PR TITLE
sane default behavior for no version tags

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,21 @@ _popd () {
     command popd > /dev/null
 }
 
+# The following option is not used, *unless*:
+#    1) you want to install a valid version git ref
+#       as a version not equal to that git ref e.g.
+#       install plugin on git tag == 1.0.0 *as*
+#       version 2.0.1 (for some reason)
+#    2) you want to install from a git sha *as* the
+#       version specified. If you want to install from
+#       a git sha, the version defaults to 0.0.1
+INSTALL_AS_VERSION="${3:-v0.0.1}"
+
+V_VERSION_REGEX='^v.*[0-9]$'
+# VERSION_REGEX='^.*[0-9]$'
+
+# TODO: allow installing from a local file path
+
 REPOSITORY="${1:-}"
 if [[ -z ${REPOSITORY} ]]; then
   errxit "Full plugin name required e.g. 'github.com/phillbaker/terraform-provider-mailgunv3'"
@@ -30,19 +45,30 @@ fi
 PLUGIN="$(basename "${REPOSITORY}")"
 PLUGIN_SHORTNAME="${PLUGIN##*-}"
 
-if [[ ! "${REPOSITORY}" =~ "://" ]]; then
+if [[ -d "${REPOSITORY}" ]]; then
+  echo "Repository is to a local path."
+elif [[ ! "${REPOSITORY}" =~ (:\/\/)|(^git@) ]]; then
+   # if protocol not specified, use https
+   # github and gitlab use 'git' user. address other use cases if/when they arise.
    REPOSITORY="https://"${REPOSITORY}
 fi
 
+echo "Installing from ${REPOSITORY}"
+
 function get_latest_version {
-  VERSIONS=($(git tag --list --format='%(refname:lstrip=2)' | grep -e '^v.*[0-9]$' | sort -r))
-  >&2 echo "Available Versions: ${VERSIONS[*]} (selecting latest)"
-  echo "${VERSIONS[0]}"
+  VERSIONS=($(git tag --list --format='%(refname:lstrip=2)' | grep -e ${V_VERSION_REGEX} | sort -r))
+  if [ ${#VERSIONS[@]} -eq 0 ]; then
+    errcho "No proper version tags found at ${REPOSITORY}. Using ${INSTALL_AS_VERSION}"
+    echo "${INSTALL_AS_VERSION}"
+  else
+    errcho "Available Versions: ${VERSIONS[*]} (selecting latest)"
+    echo "${VERSIONS[0]}"
+  fi
 }
 
 TMPWORKDIR=$(mktemp -t='tf-installer' -d || errxit "Failed to create tmpdir.")
 echo "Working in tmpdir ${TMPWORKDIR}"
-_pushd $TMPWORKDIR
+_pushd "$TMPWORKDIR"
 # clone plugin
 _GITDIR="tf-installer-clone-${PLUGIN_SHORTNAME}"
 git clone --quiet --depth 1 "${REPOSITORY}" "${_GITDIR}"
@@ -51,10 +77,32 @@ _pushd "${_GITDIR}"
 
 git fetch --quiet --tags --update-head-ok
 
-VERSION="${2:-$(get_latest_version)}"
+REVISION="${2:-$(get_latest_version)}"
 
-echo "Building ${PLUGIN} version ${VERSION}"
-git checkout "${VERSION}" --quiet --force
+# TODO(maybe): If revision was specified and matches VERSION_REGEX
+#              but does not match V_VERSION_REGEX, prepend a 'v'.
+
+echo "Building ${PLUGIN} version ${REVISION}"
+_USING_HEAD=false
+git checkout "${REVISION}" --quiet --force || _USING_HEAD=true
+
+# If INSTALL_AS_VERSION was explicitly specified, it must be used.
+# If the revision specified is not a valid version, use the fallback.
+if [[ -n "${3:-}" ]] || ! [[ "${REVISION}" =~ ${V_VERSION_REGEX} ]] ; then
+  VERSION="${INSTALL_AS_VERSION}"
+  echo "Installing revision ${REVISION} as ${VERSION}"
+else
+  VERSION="${REVISION}"
+fi
+
+# In any case, double check that the VERSION used is valid.
+if ! [[ "${VERSION}" =~ ${V_VERSION_REGEX} ]]; then
+  errxit "${VERSION} is not a valid sem version ( ${V_VERSION_REGEX})"
+fi
+
+if ${_USING_HEAD}; then
+  echo "Installing HEAD as ${VERSION}."
+fi
 
 go build -o "${HOME}/.terraform.d/plugins/${PLUGIN}_${VERSION}"
 echo "Installing ${PLUGIN} version ${VERSION}"


### PR DESCRIPTION
Allows specifying the git revision to install as well as the version to install the revision **_as_**. 

This PR enables the following use cases:
  - installing from a local path to a git repository
  - installing from any git repository (even if that repository has no valid version tags)
  - installing from any valid git ref which is passed as the second argument to the script
  - installing any of the above ways *and* specifying your desired version to install _as_, even if the version you'd like to install _as_ does not match the version/revision you want checked out for build/install
  - installing from a git repo with no tags and no version specified has sane behavior
    - installs HEAD as `0.0.1` (by default)
