### PR TITLE
mktemp -t not working as expected

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ function get_latest_version {
   fi
 }
 
-TMPWORKDIR=$(mktemp -t='tf-installer' -d || errxit "Failed to create tmpdir.")
+TMPWORKDIR=$(mktemp -t 'tf-installer.XXXXXX' -d || errxit "Failed to create tmpdir.")
 echo "Working in tmpdir ${TMPWORKDIR}"
 _pushd "$TMPWORKDIR"
 # clone plugin


### PR DESCRIPTION
This is to fix the error on most linux distributions. 

```
$ curl https://raw.githubusercontent.com/samstav/terraform-plugin-installer/master/install.sh | bash -s -- https://github.com/Mongey/terraform-provider-confluentcloud
Installing from https://github.com/Mongey/terraform-provider-confluentcloud
mktemp: invalid option -- '='
Try 'mktemp --help' for more information.
Failed to create tmpdir.
```